### PR TITLE
Deploy to Production: Show all of a category's questions

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,6 +1,6 @@
 class CategoriesController < ApplicationController
 
-  before_action :set_category, only: [:edit, :update, :destroy]
+  before_action :set_category, only: [:show, :edit, :update, :destroy]
 
   def index
     @categories = Category.all
@@ -17,6 +17,9 @@ class CategoriesController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
   end
 
   def edit

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -10,7 +10,8 @@
       .card.text-xs-center
         .card-header
           %h4= category.name
-        .list-group
-          - count = category.questions.count
-          = count
-          = (count.zero? || count > 1) ? 'Questons' : 'Question'
+        = link_to category do
+          .list-group
+            - count = category.questions.count
+            = count
+            = (count.zero? || count > 1) ? 'Questons' : 'Question'

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,0 +1,6 @@
+%h1 #{@category.name.titleize} Questions
+
+.list-group.m-t-1
+  - @category.questions.each do |question|
+    .list-group-item
+      = question.text

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -27,6 +27,11 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
       assert_response :redirect
     end
 
+    test 'show' do
+      get "/categories/#{@category.id}"
+      assert_response :success
+    end
+
     test 'edit' do
       get "/categories/#{@category.id}/edit"
       assert_response :success
@@ -57,5 +62,5 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
         { name: 'John Jacob Jingleheimer Schmidt' }
       end
     end
-    
+
 end


### PR DESCRIPTION
#14 Adds links to the `categories#show` page from the `categories#index` page to show all of a category's questions.
