### PR TITLE
Deploy to Production: Allow users to select questions

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,7 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
+ *= require users
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -1,0 +1,4 @@
+.question-category-title {
+  position: relative;
+    left: -20px;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,18 @@ class UsersController < ApplicationController
   def show
   end
 
+  def edit
+    @category_questions_array = Question.all.group_by(&:category).map { |key, value| [key, value] }
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to @user
+    else
+      render :edit
+    end
+  end
+
   private
 
   def user_params
@@ -27,7 +39,8 @@ class UsersController < ApplicationController
         :last_name,
         :email,
         :password,
-        :password_confirmation
+        :password_confirmation,
+        question_ids: []
       ])
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,8 @@
 class Question < ApplicationRecord
 
   belongs_to :category
+  has_many :user_questions, dependent: :destroy
+  has_many :users, through: :user_questions
 
   validates :text, :category_id, presence: true
   validates :text, length: { maximum: 160 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,11 +2,13 @@ class User < ApplicationRecord
   has_secure_password
 
   has_many :entries
+  has_many :user_questions, dependent: :destroy
+  has_many :questions, through: :user_questions
 
-  validates :first_name, :last_name, :email, :password, presence: true
+  validates :first_name, :last_name, :email, presence: true
   validates :email, uniqueness: true,
     format: /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
-  validates :password, confirmation: true
+  validates :password, presence: :true, confirmation: true, on: :create
 
   def name
     [first_name, last_name].join(' ')

--- a/app/models/user_question.rb
+++ b/app/models/user_question.rb
@@ -1,0 +1,4 @@
+class UserQuestion < ApplicationRecord
+  belongs_to :user
+  belongs_to :question
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,6 +20,8 @@
               = link_to Question.model_name.human.pluralize, :questions, class: 'nav-link'
             = nav_li nil, class: 'pull-xs-right' do
               = link_to 'Log Out', logout_path, method: :delete, class: 'nav-item nav-link'
+            = nav_li :users, class: 'pull-xs-right' do
+              = link_to current_user.name, [:edit, current_user], class: 'nav-item nav-link'
 
       .row
         .col-sm-12

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -10,11 +10,25 @@
       .form-group
         = f.label :email
         = f.text_field :email, class: 'form-control'
+      - if @user.new_record?
+        .form-group
+          = f.label :password
+          = f.password_field :password, class: 'form-control'
+        .form-group
+          = f.label :password_confirmation, 'Re-Type Password'
+          = f.password_field :password_confirmation, class: 'form-control'
+      - else
+        - if @category_questions_array.present?
+          %h3.m-y-2 Daily Questions
+          - @category_questions_array.in_groups_of(2).each do |category_tuple|
+            .row.m-l-1
+              - category_tuple.each do |category, category_questions|
+                .col-sm-6
+                  %h5.question-category-title= category.name
+                  = f.collection_check_boxes :question_ids, category_questions, :id, :text do |box|
+                    .form-check
+                      = box.check_box class: 'form-check-input'
+                      = box.label class: 'form-check-label'
       .form-group
-        = f.label :password
-        = f.password_field :password, class: 'form-control'
-      .form-group
-        = f.label :password_confirmation, 'Re-Type Password'
-        = f.password_field :password_confirmation, class: 'form-control'
-      .form-group
-        = f.submit 'Sign up!', class: 'btn btn-success form-control m-t-2'
+        - button_text = @user.persisted? ? 'Update' : 'Sign Up!'
+        = f.submit button_text, class: 'btn btn-success form-control m-t-2'

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,3 @@
+%h1= current_user.name
+
+= render 'form'

--- a/db/migrate/20160920030839_create_user_questions.rb
+++ b/db/migrate/20160920030839_create_user_questions.rb
@@ -1,0 +1,10 @@
+class CreateUserQuestions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :user_questions do |t|
+      t.references :user, foreign_key: true
+      t.references :question, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160827040957) do
+ActiveRecord::Schema.define(version: 20160920030839) do
 
   create_table "categories", force: :cascade do |t|
     t.string   "name"
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 20160827040957) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.index ["category_id"], name: "index_questions_on_category_id"
+  end
+
+  create_table "user_questions", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "question_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["question_id"], name: "index_user_questions_on_question_id"
+    t.index ["user_id"], name: "index_user_questions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -27,6 +27,21 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'edit' do
+    get "/users/#{@user.id}/edit"
+    assert_response :success
+  end
+
+  test 'update invalid' do
+    patch "/users/#{@user.id}", params: { user: params(:invalid) }
+    assert_response :success
+  end
+
+  test 'update valid' do
+    patch "/users/#{@user.id}", params: { user: params }
+    assert_response :redirect
+  end
+
   private
 
   def params(kind = :valid)

--- a/test/factories/user_questions.rb
+++ b/test/factories/user_questions.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :user_question do
+    association :user, factory: :user
+    association :question, factory: :question
+  end
+end

--- a/test/models/user_question_test.rb
+++ b/test/models/user_question_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class UserQuestionTest < ActiveSupport::TestCase
+
+  test 'valid' do
+    assert build(:user_question).valid?
+  end
+end


### PR DESCRIPTION
#11 Adds the ability for a user to select which questions they would like sent to them. This is acheived by the addition of the `UserQuestions` table which will allow many users to select the same question. Questions are chosen on the newly added edit user page and can currently only be added to existing users (not on signup).

Migrations will need to be run to add the joins table. 
